### PR TITLE
tiller: Add K8S_AUTH_CONTEXT env var

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -29,7 +29,7 @@ var (
 	Version = "v2.16"
 
 	// BuildMetadata is extra build time data
-	BuildMetadata = "unreleased"
+	BuildMetadata = "arista"
 	// GitCommit is the git sha1
 	GitCommit = ""
 	// GitTreeState is the state of the git tree


### PR DESCRIPTION
This allows the kube-context for tiller to be set at runtime via an env var (K8S_AUTH_CONTEXT).
This is useful when running tiller locally rather than inside the cluster.

Also setting BuildMetadata for arista branch
